### PR TITLE
support uncaching and non-automatic certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ API
   * `renewBy` (default 2 days, min 12 hours)
 * `sniCallback(domain, cb)`
 * `cacheCerts(certs)`
+* `uncacheDomain(domain)`
 
 .renewWithin
 -----------
@@ -162,7 +163,8 @@ https.createServer(httpsOptions, app);
 Manually load a certificate into the cache.
 
 This is useful in a cluster environment where the master
-may wish to inform multiple workers of a new or renewed certificate.
+may wish to inform multiple workers of a new or renewed certificate,
+or to satisfy tls-sni-01 challenges.
 
 ```
 leSni.cacheCerts({
@@ -172,5 +174,21 @@ leSni.cacheCerts({
 , altnames: [ 'example.com', 'www.example.com' ]
 , issuedAt: 1470975565000
 , expiresAt: 1478751565000
+, auto: true
 });
 ```
+
+.uncacheCerts()
+-----------
+
+Remove cached certificates from the cache.
+
+This is useful once a tls-sni-01 challenge has been satisfied.
+
+```
+leSni.uncacheCerts({
+, subject: 'example.com'
+, altnames: [ 'example.com', 'www.example.com' ]
+});
+```
+


### PR DESCRIPTION
This adds support for uncaching certificates, and for caching certificates that don't automatically renew. This facilitates temporarily installing certificates to satisfy TLS SNI challenges.

I've written a module `le-challenge-sni` which consumes this mode to do just that. Feel free to check it out. I hope you like it and it's a valuable contribution. I wrote it because I have a server behind a firewall with NAT, so the server can only receive traffic on port 443 (port 80 of our public IP is serviced by a different server behind the firewall). Using TLS SNI allows me to provision certificates entirely on port 443. As Certbot was suffering from significant installation problems, I looked around for something else, and I couldn't find anything suitable. Instead, I found your project, which was nicely modular, and thus ripe for extension. Thank you!

Since I do have another module relying on these changes, I'm really keen to get them (or something similar/equivalent) into a release fairly soon if possible.

I've updated the documentation and tests.

And I slipped in a couple of other adjustments/fixes as well:
* Promises are shared to avoid simultaneously obtaining certificates when initially loading/registering one or after expiry (the background update case has already been accounted for).
* The source seemed to use `notBefore` for `renewBy`, where I believe `notAfter` was intended; I noticed this will testing.